### PR TITLE
US89544 - Optionally include date time stamp with image src to avoid …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "/demo/"
   ],
   "dependencies": {
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.1.0",
     "polymer": "^1.8.0"
   },
   "devDependencies": {

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -69,10 +69,10 @@
 			},
 			_updateImageSource: function(newValue, oldValue) {
 				if (newValue && newValue.getLinksByClass) {
-					this._srcset = this.getImageSrcset(this.image, this.type);
+					this._srcset = this.getImageSrcset(this.image, this.type, newValue.forceImageRefresh);
 					this._tileSizes = this._generateSizes(this.sizes);
 
-					var same = oldValue && this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type);
+					var same = oldValue && !newValue.forceImageRefresh && this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type);
 					var shown = (this._imageClass || '').indexOf('shown') > -1;
 					if (same && shown) {
 						setTimeout(this._showImage.bind(this), 50);
@@ -114,7 +114,9 @@
 				if (!(image || {}).getLinksByClass) {
 					return;
 				}
-				return this.getDefaultImageLink(image, type);
+				var dateTimeString = image.forceImageRefresh ? '#' + new Date().getTime() : '';
+
+				return this.getDefaultImageLink(image, type) + dateTimeString;
 			},
 			_showImage: function() {
 				this._imageClass = 'shown';

--- a/test/d2l-course-image.js
+++ b/test/d2l-course-image.js
@@ -119,7 +119,7 @@ var image = {
 	'rel': ['https://api.brightspace.com/rels/organization-image']
 };
 
-describe('d2l-image-banner-overlay', function() {
+describe('d2l-course-image', function() {
 	var component;
 
 	beforeEach(function() {
@@ -160,5 +160,13 @@ describe('d2l-image-banner-overlay', function() {
 		var sizes = '(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw';
 		component.sizes = sizes;
 		expect(component.$$('.d2l-course-image').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
+	});
+
+	it('should include date time stamps if force image refresh is true', function() {
+		var image = window.D2L.Hypermedia.Siren.Parse(image);
+
+		image.forceImageRefresh = true;
+		component.image = image;
+		expect(component.$$('.d2l-course-image').src.search('.*#[0-9]{13}') > -1).to.be.true;
 	});
 });


### PR DESCRIPTION
…browser cache

Part 2 (of 3)

Part 1: https://github.com/Brightspace/organization-hm-behavior/pull/7 (see here for explanation why I'm using the #datetimestamp)
Part 3 will be in d2l-my-courses