### PR TITLE
Fix #10 and some style changes

### DIFF
--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -5,11 +5,6 @@
 <dom-module id="d2l-course-image">
 	<template>
 		<style>
-			:host {
-				display: flex;
-				align-items: center;
-			}
-
 			.shown {
 				animation-name: shown;
 				animation-duration: 0.5s;
@@ -22,7 +17,9 @@
 			}
 
 			img {
-				min-height: 100%;
+				object-fit: cover;
+				object-position: center;
+				height: 100%;
 				width: 100%;
 			}
 		</style>
@@ -33,7 +30,7 @@
 			sizes$="[[_tileSizes]]"
 			on-load="_showImage"
 			class$="[[_imageClass]]"
-		></img>
+		/>
 
 	</template>
 	<script>


### PR DESCRIPTION
Using object-fix/object-position is I think more in line with how we want these to act - 100% width, zoom in as the picture gets larger, and overflow on height.

Before:

![image](https://user-images.githubusercontent.com/6231623/35007615-3b346420-fac8-11e7-8c6a-bd464cbb8231.png)

After:

![image](https://user-images.githubusercontent.com/6231623/35007682-774756fc-fac8-11e7-9d0b-bb5b129b312a.png)

(This is a weirdly-shaped tile, but it's just to illustrate the difference more noticeably)