### PR TITLE
US92183 - Hybridize Course Image

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "brightspace/polymer-config"
+}

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,2 +1,0 @@
-extends:
-  brightspace/polymer-config

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ryantmer @jstefaniuk-d2l @dlockhart @capajon

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright 2018 D2L Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -201,14 +201,16 @@ To lint AND run local unit tests:
 npm test
 ```
 
-## Running tests locally in Windows
+### Running tests locally in Windows
 
-Tests in this repo use web-component-tester (WCT). Currently WCT has an issue in Windows with tests taking about a minute to start.  A workaround is to set two environment variables for Launchpad (a library used by WCT).  These help bypass browser searching which is what causes the delay.  For example:
+Tests in this repo use web-component-tester (WCT). Currently WCT has an issue in Windows with tests taking a few minutes to start.  A workaround is to set two environment variables for Launchpad (a library used by WCT).  These help bypass browser searching which is what causes the delay.  For example:
 
 ```shell
 LAUNCHPAD_BROWSERS=chrome
-LAUNCHPAD_CHROME='C:\Program Files (x86)\Google\Chrome\Application'
+LAUNCHPAD_CHROME='C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
 ```
+
+An alternative would be to run `polymer serve` and then visit `http://localhost:<port>/components/d2l-course-image/test/` in the browser you wish to run the tests on.  Using this method, you can run the tests in any local browser.
 
 ## Coding styles
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Tests in this repo use web-component-tester (WCT). Currently WCT has an issue in
 
 ```shell
 LAUNCHPAD_BROWSERS=CHROME
-LAUNCHPAD_CHROME-'C:\Program Files (x86)\Google\Chrome\Application'
+LAUNCHPAD_CHROME='C:\Program Files (x86)\Google\Chrome\Application'
 ```
 
 ## Coding styles

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # d2l-course-image
 
+[![Build status][ci-image]][ci-url]
+
 A [Polymer](https://www.polymer-project.org)-based web component D2L course-image.
 
 ## Installation
@@ -12,6 +14,77 @@ bower install git://github.com/Brightspace/course-image.git#v0.0.1
 
 ## Usage
 
+Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyfill (for browsers who don't natively support web components), then import `d2l-course-image.html`:
+
+```html
+<head>
+	<script src="../webcomponentsjs/webcomponents-lite.js"></script>
+	<link rel="import" href="../d2l-course-image/d2l-course-image.html">
+</head>
+
+Then use where needed:
+<!---
+```
+<custom-element-demo>
+  <template>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="d2l-course-image.html">
+    <style>
+      html {
+        font-size: 20px;
+      }
+      body {
+        letter-spacing: 0.01rem;
+        font-size: 0.95rem;
+        font-weight: 400;
+        line-height: 1.4rem;
+      }
+    </style>
+    <next-code-block></next-code-block>
+	<script>
+		var imageObject = {
+			'class': ['course-image'],
+			'properties': {
+				'name': 'structures_0013',
+				'categories': ['default', 'structures/support'],
+				'tags': ['carnival'],
+				'lastModified': 1485968984021
+			},
+			'entities': [{
+				'class': ['color'],
+				'properties': {
+					'description': 'vibrant',
+					'r': 130, 'g': 182, 'b': 213
+				},
+				'rel': ['https://api.brightspace.com/rels/color']
+			}],
+			'links': [{
+				'rel': ['self'],
+				'href': 'https://course-image-catalog.api.brightspace.com/images/b53fc2ae-0de4-41da-85ff-875372daeacc'
+			}, {
+				'rel': ['via'],
+				'href': 'https://www.pexels.com/photo/white-steel-ferris-wheel-89505/'
+			}, {
+				'rel': ['alternate'],
+				'class': ['tile', 'high-density', 'max'],
+				'href': 'https://s.brightspace.com/course-images/images/b53fc2ae-0de4-41da-85ff-875372daeacc/tile-high-density-max-size.jpg',
+				'type': 'image/jpeg'
+			}, {
+				'rel': ['alternate'],
+				'class': ['banner', 'narrow', 'high-density', 'min'],
+				'href': 'https://s.brightspace.com/course-images/images/b53fc2ae-0de4-41da-85ff-875372daeacc/banner-narrow-high-density-min-size.jpg',
+				'type': 'image/jpeg'
+			}],
+			'rel': ['https://api.brightspace.com/rels/organization-image']
+		};
+
+		var sirenImage = window.D2L.Hypermedia.Siren.Parse(imageObject);
+		document.body.querySelector('d2l-course-image').image = sirenImage;
+	</script>
+  </template>
+</custom-element-demo>
+```
+-->
 ```html
 <d2l-course-image type="tile" sizes="srcsetString" image="[[imageObj]]">
 </d2l-course-image>
@@ -92,15 +165,52 @@ var image = {
 </script>
 ```
 
+## Developing, Testing and Contributing
+
+After cloning the repo, run `npm install` to install dependencies.
+
+If you don't have it already, install the [Polymer CLI](https://www.polymer-project.org/2.0/docs/tools/polymer-cli) globally:
+
+```shell
+npm install -g polymer-cli
+```
+
+To start a [local web server](https://www.polymer-project.org/2.0/docs/tools/polymer-cli-commands#serve) that hosts the demo page and tests:
+
+```shell
+polymer serve
+```
+
+To lint ([eslint](http://eslint.org/) and [Polymer lint](https://www.polymer-project.org/2.0/docs/tools/polymer-cli-commands#lint)):
+
+```shell
+npm run lint
+```
+
+To run unit tests locally using [Polymer test](https://www.polymer-project.org/2.0/docs/tools/polymer-cli-commands#tests):
+
+```shell
+polymer test --skip-plugin sauce
+```
+
+To lint AND run local unit tests:
+
+```shell
+npm test
+```
+
 ## Running tests locally in Windows
 
 Tests in this repo use web-component-tester (WCT). Currently WCT has an issue in Windows with tests taking about a minute to start.  A workaround is to set two environment variables for Launchpad (a library used by WCT).  These help bypass browser searching which is what causes the delay.  For example:
 
 ```shell
-LAUNCHPAD_BROWSERS=CHROME
+LAUNCHPAD_BROWSERS=chrome
 LAUNCHPAD_CHROME='C:\Program Files (x86)\Google\Chrome\Application'
 ```
 
 ## Coding styles
 
 Use an editor which supports [EditorConfig](http://editorconfig.org).
+
+[ci-url]: https://travis-ci.org/Brightspace/course-image
+[ci-image]: https://travis-ci.org/Brightspace/course-image.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 	<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 	<link rel="import" href="../d2l-course-image/d2l-course-image.html">
 </head>
+```
 
 Then use where needed:
 <!---
@@ -28,6 +29,7 @@ Then use where needed:
 <custom-element-demo>
   <template>
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
     <link rel="import" href="d2l-course-image.html">
     <style>
       html {

--- a/all-imports.html
+++ b/all-imports.html
@@ -1,0 +1,1 @@
+<link rel="import" href="d2l-course-image.html">

--- a/bower.json
+++ b/bower.json
@@ -14,9 +14,6 @@
   "main": "d2l-course-image.html",
   "private": true,
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
     ".editorconfig",
     ".eslintrc.json",
     ".gitignore",
@@ -25,13 +22,12 @@
     "polymer.json",
     "wct.conf.json",
     "test",
-    "tests",
-    "/demo/"
+    "demo"
   ],
   "dependencies": {
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0",
-    "polymer": "1.9.1 - 2"
+    "polymer": "1 - 2"
   },
   "devDependencies": {
     "d2l-typography": "^6.0.0",

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.1.0",
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0",
     "polymer": "1.9.1 - 2"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,8 @@
     ".gitignore",
     ".travis.yml",
     "package.json",
+    "polymer.json",
+    "wct.conf.json",
     "test",
     "tests",
     "/demo/"

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,10 @@
     "polymer": "^1.8.0"
   },
   "devDependencies": {
+    "d2l-typography": "^6.0.0",
+    "iron-component-page": "^2.0.0",
+    "iron-demo-helpers": "^2.0.0",
+    "iron-test-helpers": "^2.0.0",
     "web-component-tester": "^6.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "node_modules",
     "bower_components",
     ".editorconfig",
-    ".eslintrc",
+    ".eslintrc.json",
     ".gitignore",
     ".travis.yml",
     "package.json",

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.1.0",
-    "polymer": "^1.8.0"
+    "polymer": "1.9.1 - 2"
   },
   "devDependencies": {
     "d2l-typography": "^6.0.0",
@@ -39,5 +39,18 @@
     "iron-demo-helpers": "^2.0.0",
     "iron-test-helpers": "^2.0.0",
     "web-component-tester": "^6.0.0"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "^1.9.1"
+      },
+      "resolutions": {
+        "webcomponentsjs": "^0.7.24"
+      }
+    }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^v1.0.0"
   }
 }

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -2,6 +2,13 @@
 <link rel="import" href="../d2l-intersection-observer-polyfill-import/intersection-observer.html">
 <link rel="import" href="../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 
+<!--
+`d2l-course-image`
+Polymer-based web component for course image.
+
+  @demo demo/course-image.html Course Image
+-->
+
 <dom-module id="d2l-course-image">
 	<template>
 		<style>

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -48,11 +48,22 @@ Polymer-based web component for course image.
 		Polymer({
 			is: 'd2l-course-image',
 			properties: {
+				/**
+ 				 * The type of image aspect-ratio wanted.  Supported options currently include `'tile'` and `'narrow'`.
+ 				 */
 				type: {
 					type: String,
 					value: 'tile'
 				},
+				/**
+				 * The vw (viewport-width) that the image will take up on the screen for various breakpoints.
+				 * This is used for the srcset `'sizes'` parameter, and falls back to the defaults if none provided.
+				 */
 				sizes: Object,
+				/**
+				 * The image that you want to display.  It must be in the same format as the course-catalog images,
+				 * and must be a converted into a siren entity.
+				 */
 				image: Object,
 				_imageClass: String,
 				_src: String,
@@ -61,7 +72,7 @@ Polymer-based web component for course image.
 					type: String,
 					computed: '_generateSizes(sizes)'
 				},
-				// Set by the IntersectionObserver when the image is first visible in viewport
+				// Set by the `IntersectionObserver` when the image is first visible in viewport
 				_load: Boolean
 			},
 			behaviors: [
@@ -132,6 +143,11 @@ Polymer-based web component for course image.
 					this.fire('course-image-loaded');
 				}.bind(this));
 			},
+			/**
+			 * Gets the tile sizes as a string with units, based on the `sizes` object passed into the element
+			 * (or the defaults, if that object was missing information).
+			 * @return {string}
+			 */
 			getTileSizes: function() {
 				return this._tileSizes;
 			}

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -83,7 +83,7 @@ Polymer-based web component for course image.
 			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					var imageElement = this.$$('img');
+					var imageElement = Polymer.dom(this.root).querySelector('img');
 
 					var observerCallback = function(entries, observer) {
 						for (var i = 0; i < entries.length; i++) {

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -58,6 +58,7 @@ Polymer-based web component for course image.
 				/**
 				 * The vw (viewport-width) that the image will take up on the screen for various breakpoints.
 				 * This is used for the srcset `'sizes'` parameter, and falls back to the defaults if none provided.
+				 * This can also take in a string, which will be provided directly to the srcset 'sizes' parameter.
 				 */
 				sizes: Object,
 				/**

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -10,7 +10,7 @@ Polymer-based web component for course image.
 -->
 
 <dom-module id="d2l-course-image">
-	<template>
+	<template strip-whitespace>
 		<style>
 			.shown {
 				animation-name: shown;

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -41,6 +41,10 @@ Polymer-based web component for course image.
 
 	</template>
 	<script>
+		window.D2L = window.D2L || {};
+		window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+		window.D2L.PolymerBehaviors.Hypermedia = window.D2L.PolymerBehaviors.Hypermedia || {};
+
 		Polymer({
 			is: 'd2l-course-image',
 			properties: {
@@ -61,7 +65,7 @@ Polymer-based web component for course image.
 				_load: Boolean
 			},
 			behaviors: [
-				window.D2L.Hypermedia.OrganizationHMBehavior
+				D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
 			],
 			observers: [
 				'_updateImage(_load, image, type)'

--- a/demo/course-image.html
+++ b/demo/course-image.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-course-image demo</title>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
+		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../d2l-course-image.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered">
+			<h3>Course Image</h3>
+			<demo-snippet>
+				<template>
+					<div>Default</div>
+					<d2l-course-image></d2l-course-image>
+					<script>
+						var imageObject = {
+							'class': ['course-image'],
+							'properties': {
+								'name': 'structures_0013',
+								'categories': ['default', 'structures/support'],
+								'tags': ['carnival'],
+								'lastModified': 1485968984021
+							},
+							'entities': [{
+								'class': ['color'],
+								'properties': {
+									'description': 'vibrant',
+									'r': 130, 'g': 182, 'b': 213
+								},
+								'rel': ['https://api.brightspace.com/rels/color']
+							}],
+							'links': [{
+								'rel': ['self'],
+								'href': 'https://course-image-catalog.api.brightspace.com/images/b53fc2ae-0de4-41da-85ff-875372daeacc'
+							}, {
+								'rel': ['via'],
+								'href': 'https://www.pexels.com/photo/white-steel-ferris-wheel-89505/'
+							}, {
+								'rel': ['alternate'],
+								'class': ['tile', 'high-density', 'max'],
+								'href': 'https://s.brightspace.com/course-images/images/b53fc2ae-0de4-41da-85ff-875372daeacc/tile-high-density-max-size.jpg',
+								'type': 'image/jpeg'
+							}, {
+								'rel': ['alternate'],
+								'class': ['banner', 'narrow', 'high-density', 'min'],
+								'href': 'https://s.brightspace.com/course-images/images/b53fc2ae-0de4-41da-85ff-875372daeacc/banner-narrow-high-density-min-size.jpg',
+								'type': 'image/jpeg'
+							}],
+							'rel': ['https://api.brightspace.com/rels/organization-image']
+						};
+
+						var sirenImage = window.D2L.Hypermedia.Siren.Parse(imageObject);
+						document.body.querySelector('d2l-course-image').image = sirenImage;
+					</script>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-course-image</title>
+		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../iron-component-page/iron-component-page.html">
+	</head>
+	<body>
+		<iron-component-page src="all-imports.html"></iron-component-page>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint": "^4.8.0",
-    "eslint-config-brightspace": "^0.3.1",
-    "eslint-plugin-html": "^3.2.2",
-    "polymer-cli": "^1.5.6"
+    "eslint": "^4.15.0",
+    "eslint-config-brightspace": "^0.4.0",
+    "eslint-plugin-html": "^4.0.1",
+    "polymer-cli": "^1.5.7"
   }
 }

--- a/test/d2l-course-image.js
+++ b/test/d2l-course-image.js
@@ -156,13 +156,13 @@ describe('d2l-course-image', function() {
 			desktop: { size: 33 }
 		};
 		component.sizes = sizes;
-		expect(Polymer.dom(component.root).querySelector('img').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
+		expect(Polymer.dom(component.root).querySelector('img').getAttribute('sizes')).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
 	});
 
 	it('should directly pass the sizes to the image if a string "sizes" is provided', function() {
 		var sizes = '(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw';
 		component.sizes = sizes;
-		expect(Polymer.dom(component.root).querySelector('img').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
+		expect(Polymer.dom(component.root).querySelector('img').getAttribute('sizes')).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
 	});
 
 	it('should include date time stamps if force image refresh is true', function() {

--- a/test/d2l-course-image.js
+++ b/test/d2l-course-image.js
@@ -130,23 +130,23 @@ describe('d2l-course-image', function() {
 	});
 
 	it('should exist on the page', function() {
-		expect(component.$$('.d2l-course-image') !== null).to.equal(true);
+		expect(Polymer.dom(component.root).querySelector('img') !== null).to.equal(true);
 	});
 
 	it('should not crash if not passed siren entity', function() {
 		component.image = image;
-		expect(component.$$('.d2l-course-image') !== null).to.equal(true);
+		expect(Polymer.dom(component.root).querySelector('img') !== null).to.equal(true);
 	});
 
 	it('should generate an image with the passed in class', function() {
 		component.image = sirenImage;
 		component.type = 'narrow';
-		expect(component.$$('.d2l-course-image').src.indexOf('narrow') > -1).to.equal(true);
+		expect(Polymer.dom(component.root).querySelector('img').src.indexOf('narrow') > -1).to.equal(true);
 	});
 
 	it('should generate an image with "tile" class if no class is passed in', function() {
 		component.image = sirenImage;
-		expect(component.$$('.d2l-course-image').src.indexOf('tile') > -1).to.equal(true);
+		expect(Polymer.dom(component.root).querySelector('img').src.indexOf('tile') > -1).to.equal(true);
 	});
 
 	it('should generate a srcset if a "sizes" object is passed in', function() {
@@ -156,19 +156,19 @@ describe('d2l-course-image', function() {
 			desktop: { size: 33 }
 		};
 		component.sizes = sizes;
-		expect(component.$$('.d2l-course-image').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
+		expect(Polymer.dom(component.root).querySelector('img').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
 	});
 
 	it('should directly pass the sizes to the image if a string "sizes" is provided', function() {
 		var sizes = '(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw';
 		component.sizes = sizes;
-		expect(component.$$('.d2l-course-image').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
+		expect(Polymer.dom(component.root).querySelector('img').sizes).to.equal('(max-width: 111px) 100vw, (max-width: 222px) and (min-width: 112px) 50vw, 33vw');
 	});
 
 	it('should include date time stamps if force image refresh is true', function() {
 		sirenImage.forceImageRefresh = true;
 		component.image = sirenImage;
-		expect(component.$$('.d2l-course-image').src.search('.*#[0-9]{13}') > -1).to.be.true;
+		expect(Polymer.dom(component.root).querySelector('img').src.search('.*#[0-9]{13}') > -1).to.be.true;
 	});
 
 	it('should fire a "course-image-loaded" event when the image loads', function(done) {

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,9 @@
 			'use strict';
 			// Load and run all tests (.html, .js):
 			WCT.loadSuites([
-				'./d2l-course-image.html'
+				'./d2l-course-image.html?wc-shadydom=true&wc-ce=true',
+				'./d2l-course-image.html?dom=shadow',
+				'./d2l-course-image.html?dom=shadow&lazyRegister=true&useNativeCSSProperties=true'
 			]);
 		</script>
 	</body>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -34,6 +34,11 @@
           "browserName": "microsoftedge",
           "platform": "Windows 10",
           "version": ""
+        },
+        {
+          "browserName": "internet explorer",
+          "platform": "Windows 10",
+          "version": "11"
         }
       ]
     }


### PR DESCRIPTION
- Cleanup to add consistency with other repos
- Added demo and inline docs
- Updating `$$` uses to the `Polymer.dom` functions, as the Polymer 2 guide says `$$` is unavailable in class-based elements
- Needed to rewrite the tests a bit because of https://github.com/webcomponents/shadycss/issues/113.  Shady DOM added the web component's name as a class to the internal elements, and our tests relied on that.  Shadow DOM does not do this.
- Uses the new version of `d2l-organization-hm-behavior` (where polymer was moved to Polymer 2 dev-dependency)

(Still need to go through the cleanup list one more time to see if I got everything)