### PR TITLE
Use siren-parser-import and parse passed-in image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Then use where needed:
 <custom-element-demo>
   <template>
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
     <link rel="import" href="d2l-course-image.html">
     <style>
       html {
@@ -80,8 +79,7 @@ Then use where needed:
 			'rel': ['https://api.brightspace.com/rels/organization-image']
 		};
 
-		var sirenImage = window.D2L.Hypermedia.Siren.Parse(imageObject);
-		document.body.querySelector('d2l-course-image').image = sirenImage;
+		document.body.querySelector('d2l-course-image').image = imageObject;
 	</script>
   </template>
 </custom-element-demo>
@@ -158,13 +156,6 @@ var image = {
 	'rel': ['https://api.brightspace.com/rels/organization-image']
 };
 
-```
-- The passed in image must be a siren entity, you can convert the siren-json into one by doing:
-
-```html
-<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js">
-	var sirenImage = window.D2L.Hypermedia.Siren.Parse(imageObject);
-</script>
 ```
 
 ## Developing, Testing and Contributing

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0",
-    "polymer": "1 - 2"
+    "polymer": "1 - 2",
+    "siren-parser-import": "Brightspace/siren-parser-import#^6.5.0"
   },
   "devDependencies": {
     "d2l-typography": "^6.0.0",

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-intersection-observer-polyfill-import/intersection-observer.html">
 <link rel="import" href="../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
+<link rel="import" href="../siren-parser-import/siren-parser.html">
 
 <!--
 `d2l-course-image`
@@ -62,8 +63,7 @@ Polymer-based web component for course image.
 				 */
 				sizes: Object,
 				/**
-				 * The image that you want to display.  It must be in the same format as the course-catalog images,
-				 * and must be a converted into a siren entity.
+				 * The image that you want to display.  It must be in the same format as the course-catalog images.
 				 */
 				image: Object,
 				_imageClass: String,
@@ -130,7 +130,12 @@ Polymer-based web component for course image.
 				}
 			},
 			_updateImage: function(load, image, type) {
-				if (!load || !(image || {}).getLinksByClass) {
+				if (!load || !image) {
+					return;
+				}
+				if (!image.getLinksByClass) {
+					// This will re-call _updateImage with the parsed image, so we can return immediately
+					this.image = window.D2L.Hypermedia.Siren.Parse(image);
 					return;
 				}
 				var dateTimeString = image.forceImageRefresh ? '#' + new Date().getTime() : '';

--- a/demo/course-image.html
+++ b/demo/course-image.html
@@ -5,7 +5,6 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-course-image demo</title>
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
 		<link rel="import" href="../../d2l-typography/d2l-typography.html">
@@ -66,8 +65,7 @@
 							'rel': ['https://api.brightspace.com/rels/organization-image']
 						};
 
-						var sirenImage = window.D2L.Hypermedia.Siren.Parse(imageObject);
-						document.body.querySelector('d2l-course-image').image = sirenImage;
+						document.body.querySelector('d2l-course-image').image = imageObject;
 					</script>
 				</template>
 			</demo-snippet>

--- a/test/d2l-course-image.html
+++ b/test/d2l-course-image.html
@@ -6,8 +6,6 @@
 		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../web-component-tester/browser.js"></script>
 
-		<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
-
 		<link rel="import" href="../d2l-course-image.html">
 	</head>
 	<body>


### PR DESCRIPTION
The course image shouldn't need to rely on the passed-in image being already parsed by the siren-parser - it should just parse it if required, as this makes the API for the element simpler to understand.

This is a non-breaking change, as it still works with a parsed image entity as well (which was the previous requirement).