### PR TITLE
Check src and srcset values before assignment

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
-    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0",
+    "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.2",
     "polymer": "1 - 2",
     "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"
   },

--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -135,8 +135,14 @@ Polymer-based web component for course image.
 				}
 				var dateTimeString = image.forceImageRefresh ? '#' + new Date().getTime() : '';
 
-				this._src = this.getDefaultImageLink(image, type) + dateTimeString;
-				this._srcset = this.getImageSrcset(image, type, image.forceImageRefresh);
+				var imageSrc = this.getDefaultImageLink(image, type) + dateTimeString;
+				if (imageSrc) {
+					this._src = imageSrc;
+				}
+				var imageSrcset = this.getImageSrcset(image, type, image.forceImageRefresh);
+				if (imageSrcset) {
+					this._srcset = imageSrcset;
+				}
 			},
 			_showImage: function() {
 				this._imageClass = 'shown';


### PR DESCRIPTION
It is possible for `getDefaultImageLink` and `getImageSrcset` to return undefined if the image entity we're passing in is invalid for whatever reason. If we then assign this value to `src/srcset`, we end up trying to fetch `undefined`. To avoid this, check the returned values before assigning them.

Sort-of-requires https://github.com/Brightspace/organization-hm-behavior/pull/16.

Contributing to fixing https://github.com/Brightspace/d2l-my-courses-ui/issues/507.