### PR TITLE
Add aria hidden since course image is decorative

### DIFF
--- a/d2l-course-image.html
+++ b/d2l-course-image.html
@@ -33,6 +33,7 @@ Polymer-based web component for course image.
 			sizes$="[[_tileSizes]]"
 			on-load="_showImage"
 			class$="[[_imageClass]]"
+			aria-hidden
 		/>
 
 	</template>


### PR DESCRIPTION
Image is decorative so hide it from screen readers.

>Decorative images don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.

NAMELY:

>the information provided by the image might already be given using adjacent text,

https://www.w3.org/WAI/tutorials/images/decorative/