### PR TITLE
fix: Screen reader reading course-image title

### DIFF
--- a/d2l-course-image.js
+++ b/d2l-course-image.js
@@ -51,7 +51,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-course-image">
 			}
 		</style>
 
-		<img src="[[_src]]" srcset$="[[_srcset]]" sizes$="[[_tileSizes]]" on-load="_showImage" on-error="_handleError" class$="[[_imageClass]]" alt="" aria-hidden="">
+		<img src="[[_src]]" srcset$="[[_srcset]]" sizes$="[[_tileSizes]]" on-load="_showImage" on-error="_handleError" class$="[[_imageClass]]" alt="" aria-hidden="true">
 		<div class="d2l-course-image-error-container">
 			<svg viewBox="0 0 231 103" xmlns="http://www.w3.org/2000/svg">
 				<g fill="none" fill-rule="evenodd"><path fill="#E3E9F1" d="M0 0h231v103H0z"/>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "polymer-cli": "^1.9.5",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "3.0.7",
+  "version": "3.0.8",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
## Context
[DE39947](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F408036711660)
Jaws in Firefox is reading extraneous information about course-image.

## Quality
- Needs to be tested with Jaws