### PR TITLE
US121196 - Remove error svg if reload occurs that is successful

### DIFF
--- a/d2l-course-image.js
+++ b/d2l-course-image.js
@@ -186,6 +186,7 @@ Polymer({
 		}
 	},
 	_showImage: function() {
+		this._setLoadError(false);
 		this._imageClass = 'shown';
 		afterNextRender(this, function() {
 			this.fire('course-image-loaded');

--- a/demo/course-image.html
+++ b/demo/course-image.html
@@ -56,7 +56,21 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template>
 					<div>Default</div>
-					<d2l-course-image></d2l-course-image>
+					<d2l-course-image id="success"></d2l-course-image>
+				</template>
+			</demo-snippet>
+
+			<demo-snippet>
+				<template>
+					<div>Initial Loading Error</div>
+					<d2l-course-image id="eventual-success" load-error></d2l-course-image>
+				</template>
+			</demo-snippet>
+
+			<demo-snippet>
+				<template>
+					<div>Loading Error</div>
+					<d2l-course-image load-error></d2l-course-image>
 				</template>
 			</demo-snippet>
 		</div>`;
@@ -105,7 +119,10 @@ var imageObject = {
 };
 
 window.requestAnimationFrame(function() {
-	document.body.querySelector('d2l-course-image').image = imageObject;
+	document.body.querySelector('d2l-course-image#success').image = imageObject;
+	setTimeout(() => {
+		document.body.querySelector('d2l-course-image#eventual-success').image = imageObject;
+	}, 3000);
 });
 </script>
 	</body>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "polymer-cli": "^1.9.5",
     "wct-browser-legacy": "^1.0.1"
   },
-  "version": "3.0.8",
+  "version": "3.0.9",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/test/d2l-course-image.html
+++ b/test/d2l-course-image.html
@@ -223,6 +223,18 @@ describe('d2l-course-image', function() {
 		expect(getComputedStyle(errorContainer).display).to.equal('block');
 	});
 
+	it('should show image again if successful re-load after error', function() {
+		component._handleError();
+		var img = dom(component.root).querySelector('img');
+		var errorContainer = dom(component.root).querySelector('.d2l-course-image-error-container');
+		expect(getComputedStyle(img).display).to.equal('none');
+		expect(getComputedStyle(errorContainer).display).to.equal('block');
+
+		component._showImage();
+		expect(getComputedStyle(img).display).to.equal('inline');
+		expect(getComputedStyle(errorContainer).display).to.equal('none');
+	});
+
 });
 </script>
 	</body>


### PR DESCRIPTION
When I removed the `repeat` in https://github.com/Brightspace/d2l-my-courses-ui/pull/857, I noticed this was an issue.  The DOM node reuse is causing the error svgs to remain even if the card becomes a different org that does have a valid image.